### PR TITLE
Fix period in construct() and add missing argument in getAnnotationCountForDates()

### DIFF
--- a/Piwik.php
+++ b/Piwik.php
@@ -1002,7 +1002,7 @@ class Piwik
 	 * @param integer $lastN
 	 * @param string $getAnnotationText
 	 */
-	public function getAnnotationCountForDates($lastN) {
+	public function getAnnotationCountForDates($lastN, $getAnnotationText) {
 		return $this->_request('Annotations.getAnnotationCountForDates', array(
 			'lastN' => $lastN,
 			'getAnnotationText' => $getAnnotationText

--- a/Piwik.php
+++ b/Piwik.php
@@ -60,7 +60,7 @@ class Piwik
 		$this->_token = $token;
 		$this->_siteId = $siteId;
 		$this->_format = $format;
-		$this->_period = self::PERIOD_DAY;
+		$this->_period = $period;
 		$this->_rangeStart = $rangeStart;
 		$this->_rangeEnd = $rangeEnd;
 

--- a/Piwik.php
+++ b/Piwik.php
@@ -252,7 +252,7 @@ class Piwik
 		$this->_rangeEnd = $rangeEnd;
 
 		if (is_null($rangeEnd)) {
-			$this->_date = $rangeStart;
+      $this->_rangeEnd = self::DATE_TODAY;
 		}
 
 		return $this;


### PR DESCRIPTION
The passed argument period of __constructor() is now used.
Add $getAnnotationText argument to the method getAnnotationCountForDates().