### PR TITLE
Fix bug: change _rangeEnd to today

### DIFF
--- a/Piwik.php
+++ b/Piwik.php
@@ -252,7 +252,7 @@ class Piwik
 		$this->_rangeEnd = $rangeEnd;
 
 		if (is_null($rangeEnd)) {
-			$this->_date = $rangeStart;
+      $this->_rangeEnd = self::DATE_TODAY;
 		}
 
 		return $this;


### PR DESCRIPTION
Change the _rangeEnd Date to today, because it can not be empty. It's the fallback, if there is no rangeEnd is given.