### PR TITLE
fix: Range end Date

### DIFF
--- a/src/Piwik.php
+++ b/src/Piwik.php
@@ -257,7 +257,12 @@ class Piwik
 		$this->_rangeEnd = $rangeEnd;
 
 		if (is_null($rangeEnd)) {
-			$this->_rangeEnd = self::DATE_TODAY;
+			if($this->_period == self::PERIOD_RANGE) {
+				$this->_rangeEnd = self::DATE_TODAY;
+			}
+			else {
+				$this->setDate($rangeStart);
+			}
 		}
 
 		return $this;


### PR DESCRIPTION
Fix the setRange(), because if you use the range e.g. "lastX", the end date must be blank. The Parameter looks like this: "date=lastX" and not "date=lastX,xx-xx-xx". The predefined dates e.g. "lastX" refers to the period e.g. "day". But if you use the period "range" the end Date bust be given.