### PR TITLE
Hotfix/range end date

### DIFF
--- a/src/Piwik.php
+++ b/src/Piwik.php
@@ -257,7 +257,12 @@ class Piwik
 		$this->_rangeEnd = $rangeEnd;
 
 		if (is_null($rangeEnd)) {
-			$this->_rangeEnd = self::DATE_TODAY;
+			if (strpos($rangeStart, 'last') !== false || strpos($rangeStart, 'previous') !== false
+			) {
+				$this->setDate($rangeStart);
+			} else {
+				$this->_rangeEnd = self::DATE_TODAY;
+			}
 		}
 
 		return $this;

--- a/tests/PiwikTest.php
+++ b/tests/PiwikTest.php
@@ -134,11 +134,21 @@ class PiwikTest extends PHPUnit_Framework_TestCase
 
 		$result4 = $this->_piwik->getVisits();
 		$result4 = $result4->$date;
+		$this->_piwik->reset();
+
+		// previousX respectively lastX date
+		$this->_piwik->setPeriod(Piwik::PERIOD_DAY);
+		$this->_piwik->setRange('previous7');
+
+		$result5 = $this->_piwik->getVisits();
+		$result5 = $result5->$date;
+
 
 		// Compare results
 		$this->assertEquals($result1, $result2);
 		$this->assertEquals($result2, $result3);
 		$this->assertEquals($result3, $result4);
+		$this->assertEquals($result4, $result5);
 	}
 
 	/**


### PR DESCRIPTION
Fix the setRange(), because if you use the range e.g. "lastX", the end date must be blank. The Parameter looks like this: "date=lastX" and not "date=lastX,xx-xx-xx". The predefined dates e.g. "lastX" refers to the period e.g. "day". But if you use the period "range" the end Date bust be given.
Add test case for this.