### PR TITLE
fix: CURLOPT_FOLLOWLOCATION

### DIFF
--- a/src/Piwik.php
+++ b/src/Piwik.php
@@ -341,6 +341,8 @@ class Piwik
 		curl_setopt($handle, CURLOPT_URL, $url);
 		curl_setopt($handle, CURLOPT_CONNECTTIMEOUT, 5);
 		curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
+		if(!ini_get('open_basedir'))
+			curl_setopt($handle, CURLOPT_FOLLOWLOCATION, true);
 		curl_setopt($handle, CURLOPT_FOLLOWLOCATION, true);
 		if (!$this->verifySsl)
 			curl_setopt($handle, CURLOPT_SSL_VERIFYPEER, false);


### PR DESCRIPTION
Fix the curl option "CURLOPT_FOLLOWLOCATION", because if you use "open_basedir", it is not allowed to use this curl option. 

Now the curl option "CURLOPT_FOLLOWLOCATION" will only used if the there is no "open_basedir" is in use.