### PR TITLE
Dependency and test url update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 	"license": "Apache-2.0",
 	"require": {
 		"php": ">=7",
-		"voku/httpful": "0.2.*"
+		"voku/httpful": "0.4.*"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^6.4"

--- a/tests/PiwikTest.php
+++ b/tests/PiwikTest.php
@@ -6,7 +6,7 @@ use \VisualAppeal\Piwik;
 
 class PiwikTest extends \PHPUnit\Framework\TestCase
 {
-	const TEST_SITE_URL = 'https://demo.piwik.org/';
+	const TEST_SITE_URL = 'https://demo.matomo.org/';
 
 	const TEST_SITE_ID = 7;
 


### PR DESCRIPTION
I upped the dependency since my `composer outdated` command always show this as outdated, and nothing really has changed apart from added type hinting.

Also since Piwik changed it's name to Matomo the test url needed to be updated.

Maybe this lib should rebrand but that's for another discussion / day.

Would be greatly appreciated if the dependency bump could be shipped 🚢 